### PR TITLE
Handle errors on provider level proactively, bubbling them up

### DIFF
--- a/hooked-web3-ddp-provider-client.js
+++ b/hooked-web3-ddp-provider-client.js
@@ -20,8 +20,15 @@ export class HookedWeb3DdpProvider {
   // methods to sendRawTransaction, calling out to the transaction_signer to
   // get the data for sendRawTransaction.
   sendAsync(payload, callback) {
-    const finishedWithRewrite = () => {
-      this.sendDdpRequest(payload, callback);
+    const finishedWithRewrite = (error) => {
+
+      //this function may be called with an error as an argument, we should
+      //catch it and bubble it up
+      if(error && error instanceof Error) {
+        callback(error);
+      } else {
+        this.sendDdpRequest(payload, callback);
+      }
     };
     const requests = [].concat(payload);
     this.rewritePayloads(0, requests, {}, finishedWithRewrite);

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'colony:hooked-web3-ddp-provider',
-  version: '1.0.1',
+  version: '1.0.2',
   // Brief, one-line summary of the package.
   summary: '',
   // URL to the Git repository containing the source code for this package.


### PR DESCRIPTION
Catch exceptions raised on the provider and bubble it up using the provided callback
